### PR TITLE
After starting node, copy the contents of the /data folder to the node container

### DIFF
--- a/start-node.sh
+++ b/start-node.sh
@@ -15,3 +15,5 @@ conda activate vantage6
 vnode start --config starter_head_and_neck.yaml
 
 vnode list
+
+docker cp /data/. vantage6-starter_head_and_neck-user:/mnt/data


### PR DESCRIPTION
This will allow Biomeris data files which are present in `/data/` to be available to the node when it is started.